### PR TITLE
changed push to Docker Hub on PR to on merge

### DIFF
--- a/.github/workflows/build-push-docker-images.yaml
+++ b/.github/workflows/build-push-docker-images.yaml
@@ -1,7 +1,7 @@
 name: Docker Image CI
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
 
 env:
@@ -38,4 +38,3 @@ jobs:
           push: true
           tags: 
             ${{ secrets.DOCKER_USERNAME }}/${{ env.BACKEND_IMAGE_NAME }}:latest,${{ secrets.DOCKER_USERNAME }}/arthive-app-backend:${{ github.sha }}
-            # Consider harcoding image name


### PR DESCRIPTION
## Summary
Previous workflow built and pushed images in open PRs, this should only happen after merging a pr. So I changed that

## Changes made
Changed from 
`on:
    pull_request:`

to 

`on:
    push:`


## Checklist
- [x] My PR targets the `main` branch
- [x] I've updated my branch with the latest changes from `main` (via merge or rebase)
- [x] I have tested these changes (please describe methods used to test changes below)

Closes #48 