### PR TITLE
feat: add simple JWT auth with local persistence and auto‑bearer header

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
 from jose import jwt, JWTError
 from .config import settings
 
@@ -10,7 +10,7 @@ ACCESS_EXPIRE = timedelta(
 
 def create_access_token(data: dict) -> str:
     to_encode = data.copy()
-    to_encode["exp"] = datetime.now(UTC) + ACCESS_EXPIRE
+    to_encode["exp"] = datetime.now(timezone.utc) + ACCESS_EXPIRE
     return jwt.encode(to_encode, settings.secret_key, algorithm=ALGORITHM)
 
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,11 +1,18 @@
 from datetime import datetime, timedelta, timezone
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import jwt, JWTError
+from sqlalchemy.orm import Session
+
 from .config import settings
+from .database import get_session
+from .crud_users import get_user as crud_get_user
 
 ALGORITHM = settings.algorithm
 ACCESS_EXPIRE = timedelta(
     minutes=settings.access_token_expire_minutes
 )
+bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def create_access_token(data: dict) -> str:
@@ -19,3 +26,20 @@ def verify_token(token: str):
         return jwt.decode(token, settings.secret_key, algorithms=[ALGORITHM])
     except JWTError:
         return None
+
+
+def get_current_user(
+    creds: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    session: Session = Depends(get_session),
+):
+    if creds is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="missing or invalid token")
+
+    payload = verify_token(creds.credentials)
+    if not payload:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token")
+
+    user = crud_get_user(session=session, user_id=int(payload["sub"]))
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="user not found")
+    return user

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,21 @@
+from datetime import datetime, timedelta, UTC
+from jose import jwt, JWTError
+from .config import settings
+
+ALGORITHM = settings.algorithm
+ACCESS_EXPIRE = timedelta(
+    minutes=settings.access_token_expire_minutes
+)
+
+
+def create_access_token(data: dict) -> str:
+    to_encode = data.copy()
+    to_encode["exp"] = datetime.now(UTC) + ACCESS_EXPIRE
+    return jwt.encode(to_encode, settings.secret_key, algorithm=ALGORITHM)
+
+
+def verify_token(token: str):
+    try:
+        return jwt.decode(token, settings.secret_key, algorithms=[ALGORITHM])
+    except JWTError:
+        return None

--- a/backend/app/crud_users.py
+++ b/backend/app/crud_users.py
@@ -27,20 +27,22 @@ def post_user(session: Session, user: schemas.UserCreate) -> tuple[models.User, 
     return user, None
 
 
-def login_user(session: Session, password: str, username: str = None, email: str = None):
-    err = validate_is_user(session=session, username=username, email=email)
-    err = validate_password(session=session, password=password, username=username, email=email)
-    statement = None
+def login_user(
+    session: Session, *,
+    email: str, password: str
+) -> tuple[models.User | None, str | None]:
+    err = validate_is_user(session=session, email=email)
+    if err is not None:
+        return None, err
 
-    if username is not None:
-        statement = sa.select(models.User).where(models.User.username == username)
+    err = validate_password(session=session, password=password, email=email)
+    if err is not None:
+        return None, err
 
-    if email is not None:
-        statement = sa.select(models.User).where(models.User.email == email)
+    stmt = sa.select(models.User).where(models.User.email == email)
+    user = session.scalars(stmt).first()
 
-    user = session.scalars(statement).first()
-
-    return user, err
+    return user, None
 
 
 def get_user(session: Session, user_id: int):

--- a/backend/app/routers/user.py
+++ b/backend/app/routers/user.py
@@ -9,8 +9,6 @@ from ..database import get_session
 # User-related endpoints
 router = APIRouter()
 
-bearer_scheme = HTTPBearer(auto_error=False)
-
 
 @router.get("/users/{user_id}", response_model=schemas.UserResponse)
 def get_user(
@@ -70,23 +68,6 @@ def login_user(
         "access_token": token,
         "user": schemas.UserResponse.model_validate(user),
     }
-
-
-def get_current_user(
-    creds: HTTPAuthorizationCredentials = Depends(bearer_scheme),
-    session: Session = Depends(get_session),
-):
-    if creds is None:
-        raise HTTPException(status_code=401, detail="missing or invalid token")
-
-    payload = verify_token(creds.credentials)
-    if not payload:
-        raise HTTPException(status_code=401, detail="invalid token")
-
-    user = crud_users.get_user(session=session, user_id=int(payload["sub"]))
-    if user is None:
-        raise HTTPException(status_code=404, detail="user not found")
-    return user
 
 
 @router.put("/users/{user_id}", response_model=schemas.UserResponse)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -19,12 +19,6 @@ class UserUpdate(BaseModel):
     # password: Optional[str] = None
 
 
-class UserLogin(BaseModel):
-    email: Optional[EmailStr] = None
-    username: Optional[str] = None
-    password: str
-
-
 class UserResponse(BaseModel):
     id: int
     name: str
@@ -34,6 +28,17 @@ class UserResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    user: UserResponse
 
 
 # Post related schemas
@@ -62,6 +67,7 @@ class PostResponse(PostBase):
     created_at: datetime
     user_id: int
     img_url: str
+
     # comments : list[Comment]
     # like_count: int  # to be computed from Like table
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -52,3 +52,4 @@ uvloop==0.21.0
 virtualenv==20.31.2
 watchfiles==1.1.0
 websockets==15.0.1
+python-jose[cryptography]==3.3.0

--- a/frontend/src/_lib/apiClient.js
+++ b/frontend/src/_lib/apiClient.js
@@ -1,6 +1,14 @@
 import axios from 'axios'
 
+import { getToken } from './authStore.js'
+
 export const apiClient = axios.create({
   baseURL: import.meta.env.API_URL ?? 'http://127.0.0.1:8000',
   withCredentials: false,
+})
+
+apiClient.interceptors.request.use((cfg) => {
+  const token = getToken()
+  if (token) cfg.headers.Authorization = `Bearer ${token}`
+  return cfg
 })

--- a/frontend/src/_lib/authStore.js
+++ b/frontend/src/_lib/authStore.js
@@ -1,0 +1,18 @@
+const TOKEN_KEY = 'arthive_token'
+const USER_KEY = 'arthive_user'
+
+export const saveAuth = ({ token, user }) => {
+  localStorage.setItem(TOKEN_KEY, token)
+  localStorage.setItem(USER_KEY, JSON.stringify(user))
+}
+
+export const getToken = () => localStorage.getItem(TOKEN_KEY)
+export const getUser = () => {
+  const raw = localStorage.getItem(USER_KEY)
+  return raw ? JSON.parse(raw) : null
+}
+
+export const clearAuth = () => {
+  localStorage.removeItem(TOKEN_KEY)
+  localStorage.removeItem(USER_KEY)
+}

--- a/frontend/src/auth/Login/hooks/useLogin.js
+++ b/frontend/src/auth/Login/hooks/useLogin.js
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { saveAuth } from '../../../_lib/authStore'
 import { loginUser } from '../services/loginUser'
 
 export const useLogin = () => {
@@ -8,19 +9,20 @@ export const useLogin = () => {
   const [apiError, setApiError] = useState(null)
   const navigate = useNavigate()
 
-  const submit = async (payload) => {
+  const submit = async (creds) => {
     setSubmitting(true)
     setApiError(null)
 
     try {
-      await loginUser(payload)
+      const { access_token, user } = await loginUser(creds)
+      saveAuth({ token: access_token, user })
       navigate('/', { replace: true })
     } catch (err) {
       const code = err?.response?.status
-      if (code === 404) {
-        setApiError('🐝 Account not found - check your email!')
-      } else if (code === 409) {
-        setApiError('🐝 Incorrect password - give it another buzz!')
+      if (code === 401) {
+        setApiError('🐝 Invalid credentials – give it another buzz!')
+      } else if (code === 422) {
+        setApiError('🐝 Missing or invalid fields – check your inputs!')
       } else {
         setApiError("🐝 Stung by a glitch! We couldn't log you in.")
       }

--- a/frontend/src/auth/Login/services/loginUser.js
+++ b/frontend/src/auth/Login/services/loginUser.js
@@ -1,3 +1,3 @@
 import { apiClient } from '../../../_lib/apiClient.js'
 
-export const loginUser = (payload) => apiClient.post('/users/login', payload)
+export const loginUser = (payload) => apiClient.post('/users/login', payload).then((r) => r.data)


### PR DESCRIPTION
### Summary  
Adds a very simple JWT‑based login flow and redefines up the `/users/login` contract so the frontend can reliably authenticate and receive a minimal user object (no `password_hash`).

**Important**! The `python-jose` lib doesn' t support SHA256, so use HS256 instead. It'll not work with SHA256! You might need to rebuild the image.

Example .env:
```env
DATABASE_NAME=arthive
DATABASE_HOSTNAME=postgres-db
DATABASE_PORT=5432
DATABASE_USERNAME=postgres
DATABASE_PASSWORD=password
SECRET_KEY=password
ALGORITHM=HS256
ACCESS_TOKEN_EXPIRE_MINUTES=60
```

### Changes made
| Area | What changed |
|----------------------------|------------------------------------------------------------------------------------------|
| **app/schemas.py**         | Added `LoginRequest` and `TokenResponse` models |
| **app/routers/user.py**    | `/users/login` now accepts JSON, returns JWT + user via `TokenResponse`, hides `password_hash`, documents 401/422 |
| **app/auth.py**            | Token creation/verification utilities  |
| **Swagger/OpenAPI**        | Clean request/response models (no `password_hash`), shows 401/422 |

### Checklist
- [x] PR targets **`main`**
- [x] Branch rebased/merged with latest **`main`**
- [x] Integrate FE login
- [x] Test with Swagger UI:  
  - POST /users/login
  - 200 response example:
```json
{
  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiZXhwIjoxNzUzMzI1NDg0fQ.wbWcuVQMDUcqcdVGMn6xNDPS84nUdSdaKboLXH17hkY",
  "token_type": "bearer",
  "user": {
    "id": 1,
    "name": "Thorfinn Thorsson",
    "email": "thorfinn@vinland.vi",
    "username": "thorfinn",
    "created_at": "2025-07-24T01:16:07.461048"
  }
}
```
- [x] Test by logging in with a valid email and password: after being redirected to `/`, open DevTools, check application tab and make sure that you `arthive_token` and `arthive_user` have been created (see the image below for an example)

### Evidences
<img width="1833" height="1046" alt="image" src="https://github.com/user-attachments/assets/d6263ccd-d6f1-4d97-8fb4-8477fffa9c70" />

### References
- FastAPI docs - [JSON body vs form data](https://fastapi.tiangolo.com/tutorial/body/)  
- [python-jose](https://pypi.org/project/python-jose/)
